### PR TITLE
Fix tag parsing so it doesn't die when it ends with a letter that's a rating.

### DIFF
--- a/scripts/e621.coffee
+++ b/scripts/e621.coffee
@@ -62,7 +62,8 @@ getPost = (robot, tags, rating) ->
     if error is ""
       tag = JSON.parse(body)
       if tag.length > 0
-        promise.resolve(tag[0]["sample_url"])
+        #I just didn't want to pass in the msg object. :(
+        promise.resolve(tag[Math.floor(Math.random()*tag.length)]["sample_url"])
       else
         promise.reject("No posts found.")
     else


### PR DESCRIPTION
If you search for the single tag "poops" it will search for "poop" on
rating s. If you really want to search "poops" then you will have to
provide the rating explicitly. Even if it's the default rating you want.
